### PR TITLE
Update stripe.md

### DIFF
--- a/docs/stripe.md
+++ b/docs/stripe.md
@@ -528,7 +528,7 @@ create foreign table stripe.prices (
 )
   server stripe_server
   options (
-    object 'pricing'
+    object 'prices'
   );
 ```
 


### PR DESCRIPTION
Using "pricing" as object value returns "pricing object not implemented" error while querying and after changing the object to "prices" the error is resolved.